### PR TITLE
ci!: fix release workflow and improve it

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -37,13 +37,8 @@ jobs:
         with:
           go-version: ${{ needs.setup.outputs.go_version }}
 
-      - name: Build binary
-        run: |
-          env GOOS=linux GOARCH=amd64 go build -o dist/linux-x64
-          env GOOS=linux GOARCH=arm64 go build -o dist/linux-arm64
-          env GOOS=darwin GOARCH=amd64 go build -o dist/macos-x64
-          env GOOS=darwin GOARCH=arm64 go build -o dist/macos-arm64
-          env GOOS=windows GOARCH=amd64 go build -o dist/windows-x64
+      - name: Build binaries
+        run: make build
 
       - name: Determine next version
         id: next-version
@@ -58,6 +53,9 @@ jobs:
           fi
 
           echo "next-version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update version references in README
+        run: make update-readme-version VERSION=${{ steps.next-version.outputs.next-version }}
 
       - name: Create tag
         run: |

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -47,50 +47,30 @@ jobs:
 
       - name: Output vars
         id: vars
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LAST_TAG=$(git for-each-ref "refs/tags/v*" --sort=-committerdate:relative --format='%(refname)' --count=1 | sed "s/refs\/tags\///" )
-          LAST_TAG_CONTAINS_RC=false
-          IS_PRE_RELEASE=false
-          BUMP_TYPE="patch"
+          # Get latest tag matching v* pattern, sorted by version number
+          LAST_TAG=$(git tag --list "v*" --sort=-v:refname | head --lines=1)
 
-          if [[ $LAST_TAG == *"-rc"* ]]; then
-              LAST_TAG_CONTAINS_RC=true
-          fi
-
-          if [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
-              IS_PRE_RELEASE=true
-
-              if [[ $LAST_TAG_CONTAINS_RC == true ]]; then
-                  BUMP_TYPE=prerelease
-              else
-                  BUMP_TYPE=prepatch
-              fi
+          if [[ -z "$LAST_TAG" ]]; then
+            # No tags exist yet, start at v1
+            NEXT_VERSION="v1"
           else
-              BUMP_TYPE=patch
+            # Extract version number and increment
+            VERSION_NUM=${LAST_TAG#v}
+            NEXT_NUM=$((VERSION_NUM + 1))
+            NEXT_VERSION="v${NEXT_NUM}"
           fi
 
-          NEXT_VERSION="v$(npx semver "$LAST_TAG" -i $BUMP_TYPE --preid rc)"
-
-          echo "::set-output name=is-pre-release::$IS_PRE_RELEASE"
-          echo "::set-output name=next-version::$NEXT_VERSION"
+          echo "next-version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
         run: |
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
           git add .
-          git commit -m 'release: ${{ steps.vars.outputs.next-version }}'
+          git commit --message 'release: ${{ steps.vars.outputs.next-version }}'
           git tag ${{ steps.vars.outputs.next-version }}
           git push origin --tags
-
-          if [[ "${{ steps.vars.outputs.is-pre-release }}" == false ]]; then
-            MAJOR_TAG=$(echo "${{ steps.vars.outputs.next-version }}" | sed "s/\..*//")
-
-            git tag $MAJOR_TAG -f -a -m "Update tag with version ${{ steps.vars.outputs.next-version }}"
-            git push origin tag $MAJOR_TAG --force
-          fi
 
       - name: Create Release
         id: create_release
@@ -102,5 +82,5 @@ jobs:
           release_name: ${{ steps.vars.outputs.next-version }}
           body: ""
           draft: false
-          prerelease: ${{ steps.vars.outputs.is-pre-release }}
+          prerelease: false
 

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -45,20 +45,16 @@ jobs:
           env GOOS=darwin GOARCH=arm64 go build -o dist/macos-arm64
           env GOOS=windows GOARCH=amd64 go build -o dist/windows-x64
 
-      - name: Output vars
-        id: vars
+      - name: Determine next version
+        id: next-version
         run: |
-          # Get latest tag matching v* pattern, sorted by version number
           LAST_TAG=$(git tag --list "v*" --sort=-v:refname | head --lines=1)
 
           if [[ -z "$LAST_TAG" ]]; then
-            # No tags exist yet, start at v1
             NEXT_VERSION="v1"
           else
-            # Extract version number and increment
             VERSION_NUM=${LAST_TAG#v}
-            NEXT_NUM=$((VERSION_NUM + 1))
-            NEXT_VERSION="v${NEXT_NUM}"
+            NEXT_VERSION="v$((VERSION_NUM + 1))"
           fi
 
           echo "next-version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
@@ -68,8 +64,8 @@ jobs:
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
           git add .
-          git commit --message 'release: ${{ steps.vars.outputs.next-version }}'
-          git tag ${{ steps.vars.outputs.next-version }}
+          git commit --message 'release: ${{ steps.next-version.outputs.next-version }}'
+          git tag ${{ steps.next-version.outputs.next-version }}
           git push origin --tags
 
       - name: Create Release
@@ -78,8 +74,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.vars.outputs.next-version }}
-          release_name: ${{ steps.vars.outputs.next-version }}
+          tag_name: ${{ steps.next-version.outputs.next-version }}
+          release_name: ${{ steps.next-version.outputs.next-version }}
           body: ""
           draft: false
           prerelease: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       go_version: ${{ steps.go-version.outputs.version }}
     steps:
@@ -28,6 +28,7 @@ jobs:
           echo "version=$GO_VERSION" >> "$GITHUB_OUTPUT"
 
   test:
+    needs: setup
     name: Test on Linux
     runs-on: ubuntu-latest
     services:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 GO_VERSION := $(shell grep '^go ' go.mod | cut -d' ' -f2)
 
 .PHONY: print-go-version
-print-go-version: ## Print Go version from go.mod
+print-go-version:
 	@echo $(GO_VERSION)
+
+.PHONY: build
+build:
+	GOOS=linux GOARCH=amd64 go build -o dist/linux-x64
+	GOOS=linux GOARCH=arm64 go build -o dist/linux-arm64
+	GOOS=darwin GOARCH=amd64 go build -o dist/macos-x64
+	GOOS=darwin GOARCH=arm64 go build -o dist/macos-arm64
+	GOOS=windows GOARCH=amd64 go build -o dist/windows-x64
+
+.PHONY: update-readme-version
+update-readme-version:
+ifndef VERSION
+	$(error VERSION is required, e.g. make update-readme-version VERSION=v3)
+endif
+	sed --in-place --regexp-extended 's|action-s3-cache@v[0-9]+|action-s3-cache@$(VERSION)|g' README.md

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ The following example shows a simple pipeline using S3 Cache GitHub Action:
 
 This action uses pre-compiled Go binaries that are built and committed to version control automatically by CI.
 
-### Making changes
+- [ ] TODO Change to uploading built binaries to GitHub release assets instead of committing to version control (this would prevent bloating the repo size and history)
 
 1. Create a branch and make your code changes to the Go source files
 2. Open a PR targeting `develop`
-3. Once merged, CI will automatically build binaries for all platforms and create a pre-release (`vX.Y.Z-rcN`)
+3. Once merged, CI will automatically build binaries for all platforms and create a new release (`v1`, `v2`, `v3`, etc.)


### PR DESCRIPTION
## What

- Fix broken release process in CI (hopefully), currently it fails (see [here](https://github.com/everestsystems/action-s3-cache/actions/runs/20303288736/job/58314043495#step:5:32))
- Simplify release versioning tag scheme to just `v1`, `v2`, `v3`, etc. instead of semver (as we already have a `v2` version tag)
- Move commands to the `Makefile`
- Update the references to the latest version in the `README` after a release
- Also fix a bug in the `.github/workflows/test.yml` workflow and make its `setup` run on `ubuntu-slim`