### PR TITLE
build: fix commiting of new binaries and doc changes

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,14 +57,14 @@ jobs:
       - name: Update version references in README
         run: make update-readme-version VERSION=${{ steps.next-version.outputs.next-version }}
 
-      - name: Create tag
+      - name: Commit and tag release
         run: |
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
           git add .
           git commit --message 'release: ${{ steps.next-version.outputs.next-version }}'
           git tag ${{ steps.next-version.outputs.next-version }}
-          git push origin --tags
+          git push origin develop --tags
 
       - name: Create Release
         id: create_release

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ print-go-version:
 
 .PHONY: build
 build:
+	rm --recursive --force dist/
 	GOOS=linux GOARCH=amd64 go build -o dist/linux-x64
 	GOOS=linux GOARCH=arm64 go build -o dist/linux-arm64
 	GOOS=darwin GOARCH=amd64 go build -o dist/macos-x64


### PR DESCRIPTION
## What

- Follow-up to https://github.com/everestsystems/action-s3-cache/pull/6 to fix the bug of the tagged release commit not being pushed to the `develop` branch
  - See https://github.com/everestsystems/action-s3-cache/releases/tag/v3 for an example of the bug as release `v3` is from the commit 052ba840cf31c35904c84e512448381ee3c23da4 that doesn't belong to any branch
- Also ensure to clean the binary directory `/dist`