### PR TITLE
ci: bump Go workflow actions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -14,7 +14,7 @@ jobs:
       go_version: ${{ steps.go-version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Go
         # As this repo is a public fork the public setup-go action is used here instead of our private one
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ steps.go-version.outputs.version }}
 
@@ -75,7 +75,7 @@ jobs:
     if: ${{ startsWith(github.event.head_commit.message, 'chore(release):') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version from commit message
         id: version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       go_version: ${{ steps.go-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract Go version from go.mod
         id: go-version
@@ -40,11 +40,11 @@ jobs:
           SERVICES: s3
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         # As this repo is a public fork the public setup-go action is used here instead of our private one
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ needs.setup.outputs.go_version }}
 


### PR DESCRIPTION
## What

- Bump `actions/setup-go` from `v5` to `v6` in the build and test workflows.
- Bump `actions/checkout` from `v4` to `v6` in the same workflows.
- Keep the workflow inputs, release behaviour, and test behaviour otherwise unchanged.

## Why

- `actions/setup-go@v6` and `actions/checkout@v6` run on Node 24.
- The repo is a public fork and already intentionally uses the public `actions/setup-go` action rather than our internal wrapper.
- Bumping `checkout` at the same time removes the other outdated JavaScript action still present in these workflows.

## Notes

- `actions/setup-go@v6` requires Actions Runner `2.327.1` or newer.
- I checked the repo for other external action usages; after this change the remaining `uses: ./` entries are local action tests, not marketplace actions.
