### PR TITLE
fix: stream S3 cache download to disk to avoid OOM on large caches

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -81,16 +81,14 @@ func GetObject(key, bucket string) error {
 		return err
 	}
 	defer file.Close()
-	body, err := io.ReadAll(result.Body)
+	written, err := io.Copy(file, result.Body)
 	if err != nil {
-		log.Printf("Couldn't read object body from %v: %v\n", key, err)
+		log.Printf("Couldn't write object body to %v: %v\n", key, err)
+		return err
 	}
 
-	_, err = file.Write(body)
-	if err == nil {
-		log.Printf("Cache downloaded successfully, containing %d bytes", result.ContentLength)
-	}
-	return err
+	log.Printf("Cache downloaded successfully, containing %d bytes", written)
+	return nil
 }
 
 // DeleteObject - Delete object from s3 bucket


### PR DESCRIPTION
## What

`GetObject` in `s3.go` now streams the S3 cache object straight to disk with `io.Copy`, instead of first buffering the whole tarball in memory with `io.ReadAll`.

## Why

On self-hosted `linux-x64-small` runners the Go cache tarball has grown to about 2.26 GB. `io.ReadAll` loads the entire object into RAM (and peaks near twice that while the buffer grows), which exceeds the runner's memory and gets the process OOM-killed (SIGKILL, exit 137) during the `Retrieve cache` step. This broke every `base-coverage` run in the lambdas repo, and re-running did not help because the object size and the runner memory are both fixed.

Failing run: https://github.com/everestsystems/lambdas/actions/runs/28515042838/job/84530583500

Streaming to disk keeps memory flat regardless of cache size, so a restore no longer requires the runner to have as much RAM as the cache is large.

## Notes

- Only `s3.go` changes. The `dist/*` binaries are left untouched on purpose; the release workflow rebuilds them on merge to `develop`.
- `PutObject` already streamed from a file handle, so only the download path needed fixing.
- The success log now reports the bytes actually written (the `io.Copy` return value) rather than `result.ContentLength`. Same number, one less field to trust.
- Purging the oversized object from S3 was the immediate unblock; this change is the durable fix so the OOM does not recur as the cache grows again.
