### PR TITLE
fix: make release branch push and PR creation idempotent

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -59,16 +59,18 @@ jobs:
 
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git add .
           git commit --message "chore(release): ${{ steps.next-version.outputs.next-version }}"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
 
-          gh pr create \
-            --title "chore(release): ${{ steps.next-version.outputs.next-version }}" \
-            --body "Automated release PR with built binaries for ${{ steps.next-version.outputs.next-version }}" \
-            --base develop \
-            --head "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --title "chore(release): ${{ steps.next-version.outputs.next-version }}" \
+              --body "Automated release PR with built binaries for ${{ steps.next-version.outputs.next-version }}" \
+              --base develop \
+              --head "$BRANCH"
+          fi
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -59,7 +59,7 @@ jobs:
 
           git config --global user.email "${{ github.event.pusher.email }}"
           git config --global user.name "${{ github.event.pusher.name }}"
-          git checkout -B "$BRANCH"
+          git switch -C "$BRANCH"
           git add .
           git commit --message "chore(release): ${{ steps.next-version.outputs.next-version }}"
           git push --force origin "$BRANCH"
@@ -70,6 +70,8 @@ jobs:
               --body "Automated release PR with built binaries for ${{ steps.next-version.outputs.next-version }}" \
               --base develop \
               --head "$BRANCH"
+          else
+            echo "Open PR already exists for $BRANCH, skipping PR creation."
           fi
 
   release:


### PR DESCRIPTION
The `Create release PR` step fails when a `release/vN` branch and its open PR already exist from a prior run (non-fast-forward push rejection).

Since the version is derived from the last tag, re-runs recompute the same `release/vN` branch name and collide with the leftover branch.

Changes:
- `git checkout -B` to reset the local release branch instead of failing if it exists
- `git push --force` since the release branch is a disposable automation branch
- Skip `gh pr create` when an open PR for the branch already exists

Related to https://github.com/everestsystems/action-s3-cache/actions/runs/28525070482